### PR TITLE
Remove stray <!doctype> below copyright notice

### DIFF
--- a/basic/configure-privacy/demo.html
+++ b/basic/configure-privacy/demo.html
@@ -14,8 +14,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-
-<!doctype html>
 <html>
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
<!doctype> seems to have been included twice in this sample.