### PR TITLE
Fix a bug in gaming interstitial demo where event listeners are registered multiple times

### DIFF
--- a/dist/display-gaming-interstitial-ad/js/demo.html
+++ b/dist/display-gaming-interstitial-ad/js/demo.html
@@ -22,7 +22,10 @@
 
       googletag.cmd.push(() => {
         // Define a gaming interstitial ad slot.
-        defineGamingInterstitialSlot();
+        defineGamingInterstitialSlot(true);
+
+        // Add gaming interstitial event listeners.
+        addGamingInterstitialListeners();
 
         // Define static ad slots.
         googletag
@@ -34,7 +37,9 @@
         googletag.enableServices();
       });
 
-      function defineGamingInterstitialSlot() {
+      function defineGamingInterstitialSlot(delay) {
+        document.getElementById("trigger").style.display = "none";
+
         gamingInterstitialSlot = googletag.defineOutOfPageSlot(
           "/6355419/Travel/Europe/France/Paris",
           googletag.enums.OutOfPageFormat.GAME_MANUAL_INTERSTITIAL,
@@ -43,43 +48,55 @@
         // Slot returns null if the page or device does not support interstitials.
         if (gamingInterstitialSlot) {
           gamingInterstitialSlot.addService(googletag.pubads());
+          if (!delay) {
+            googletag.display(gamingInterstitialSlot);
+          }
           printStatus("Waiting for interstitial to be ready...");
-
-          // Add event listener to register click handler once interstitial loads.
-          // If this event doesn't fire, check the browser console for errors.
-          googletag
-            .pubads()
-            .addEventListener("gameManualInterstitialSlotReady", (slotReadyEvent) => {
-              if (gamingInterstitialSlot === slotReadyEvent.slot) {
-                printStatus("Interstitial is ready.");
-
-                const button = document.getElementById("trigger");
-                button.style.display = "block";
-                button.addEventListener(
-                  "click",
-                  () => {
-                    slotReadyEvent.makeGameManualInterstitialVisible();
-                    printStatus("Interstitial is active.");
-                  },
-                  { once: true },
-                );
-              }
-            });
-
-          googletag.pubads().addEventListener("gameManualInterstitialSlotClosed", resumeGame);
+        } else {
+          printStatus("This device does not support interstitials.");
         }
       }
 
+      function addGamingInterstitialListeners() {
+        // Add event listener to register click handler once interstitial loads.
+        // If this event doesn't fire, check the browser console for errors.
+        googletag.pubads().addEventListener("gameManualInterstitialSlotReady", (slotReadyEvent) => {
+          if (gamingInterstitialSlot === slotReadyEvent.slot) {
+            printStatus("Interstitial is ready.");
+
+            const button = document.getElementById("trigger");
+            button.style.display = "block";
+            button.addEventListener(
+              "click",
+              () => {
+                pauseGame();
+
+                slotReadyEvent.makeGameManualInterstitialVisible();
+                printStatus("Interstitial is active.");
+              },
+              { once: true },
+            );
+          }
+        });
+
+        googletag.pubads().addEventListener("gameManualInterstitialSlotClosed", () => {
+          // Gaming interstitial ad slots are one-time use, so destroy the old slot
+          // and create a new one.
+          if (gamingInterstitialSlot) {
+            googletag.destroySlots([gamingInterstitialSlot]);
+          }
+          defineGamingInterstitialSlot(false);
+
+          resumeGame();
+        });
+      }
+
+      function pauseGame() {
+        // Code to pause the game.
+      }
+
       function resumeGame() {
-        if (!gamingInterstitialSlot) return;
-
-        document.getElementById("trigger").style.display = "none";
-
-        // Gaming interstitial ad slots are one-time use, so destroy the old slot
-        // and create a new one.
-        googletag.destroySlots([gamingInterstitialSlot]);
-        defineGamingInterstitialSlot();
-        googletag.display(gamingInterstitialSlot);
+        // Code to resume the game.
       }
 
       function printStatus(status) {

--- a/dist/display-gaming-interstitial-ad/js/demo.html
+++ b/dist/display-gaming-interstitial-ad/js/demo.html
@@ -22,7 +22,7 @@
 
       googletag.cmd.push(() => {
         // Define a gaming interstitial ad slot.
-        defineGamingInterstitialSlot(true);
+        defineGamingInterstitialSlot();
 
         // Add gaming interstitial event listeners.
         addGamingInterstitialListeners();
@@ -37,7 +37,7 @@
         googletag.enableServices();
       });
 
-      function defineGamingInterstitialSlot(delay) {
+      function defineGamingInterstitialSlot() {
         document.getElementById("trigger").style.display = "none";
 
         gamingInterstitialSlot = googletag.defineOutOfPageSlot(
@@ -48,12 +48,11 @@
         // Slot returns null if the page or device does not support interstitials.
         if (gamingInterstitialSlot) {
           gamingInterstitialSlot.addService(googletag.pubads());
-          if (!delay) {
-            googletag.display(gamingInterstitialSlot);
-          }
           printStatus("Waiting for interstitial to be ready...");
+          return true;
         } else {
           printStatus("This device does not support interstitials.");
+          return false;
         }
       }
 
@@ -85,7 +84,10 @@
           if (gamingInterstitialSlot) {
             googletag.destroySlots([gamingInterstitialSlot]);
           }
-          defineGamingInterstitialSlot(false);
+
+          if (defineGamingInterstitialSlot()) {
+            googletag.display(gamingInterstitialSlot);
+          }
 
           resumeGame();
         });
@@ -127,7 +129,9 @@
         // Ensure the first call to display comes after static ad slot
         // divs are defined. If you do not have any static ad slots, this
         // call can be made immediately after services are enabled.
-        googletag.display(gamingInterstitialSlot);
+        if (gamingInterstitialSlot) {
+          googletag.display(gamingInterstitialSlot);
+        }
       });
     </script>
   </body>

--- a/dist/display-gaming-interstitial-ad/legacyjs/demo.html
+++ b/dist/display-gaming-interstitial-ad/legacyjs/demo.html
@@ -22,7 +22,7 @@
 
       googletag.cmd.push(function () {
         // Define a gaming interstitial ad slot.
-        defineGamingInterstitialSlot(true);
+        defineGamingInterstitialSlot();
 
         // Add gaming interstitial event listeners.
         addGamingInterstitialListeners();
@@ -37,7 +37,7 @@
         googletag.enableServices();
       });
 
-      function defineGamingInterstitialSlot(delay) {
+      function defineGamingInterstitialSlot() {
         document.getElementById("trigger").style.display = "none";
 
         gamingInterstitialSlot = googletag.defineOutOfPageSlot(
@@ -48,12 +48,11 @@
         // Slot returns null if the page or device does not support interstitials.
         if (gamingInterstitialSlot) {
           gamingInterstitialSlot.addService(googletag.pubads());
-          if (!delay) {
-            googletag.display(gamingInterstitialSlot);
-          }
           printStatus("Waiting for interstitial to be ready...");
+          return true;
         } else {
           printStatus("This device does not support interstitials.");
+          return false;
         }
       }
 
@@ -87,7 +86,10 @@
           if (gamingInterstitialSlot) {
             googletag.destroySlots([gamingInterstitialSlot]);
           }
-          defineGamingInterstitialSlot(false);
+
+          if (defineGamingInterstitialSlot()) {
+            googletag.display(gamingInterstitialSlot);
+          }
 
           resumeGame();
         });
@@ -129,7 +131,9 @@
         // Ensure the first call to display comes after static ad slot
         // divs are defined. If you do not have any static ad slots, this
         // call can be made immediately after services are enabled.
-        googletag.display(gamingInterstitialSlot);
+        if (gamingInterstitialSlot) {
+          googletag.display(gamingInterstitialSlot);
+        }
       });
     </script>
   </body>

--- a/dist/display-gaming-interstitial-ad/legacyjs/demo.html
+++ b/dist/display-gaming-interstitial-ad/legacyjs/demo.html
@@ -22,7 +22,10 @@
 
       googletag.cmd.push(function () {
         // Define a gaming interstitial ad slot.
-        defineGamingInterstitialSlot();
+        defineGamingInterstitialSlot(true);
+
+        // Add gaming interstitial event listeners.
+        addGamingInterstitialListeners();
 
         // Define static ad slots.
         googletag
@@ -34,7 +37,9 @@
         googletag.enableServices();
       });
 
-      function defineGamingInterstitialSlot() {
+      function defineGamingInterstitialSlot(delay) {
+        document.getElementById("trigger").style.display = "none";
+
         gamingInterstitialSlot = googletag.defineOutOfPageSlot(
           "/6355419/Travel/Europe/France/Paris",
           googletag.enums.OutOfPageFormat.GAME_MANUAL_INTERSTITIAL,
@@ -43,43 +48,57 @@
         // Slot returns null if the page or device does not support interstitials.
         if (gamingInterstitialSlot) {
           gamingInterstitialSlot.addService(googletag.pubads());
+          if (!delay) {
+            googletag.display(gamingInterstitialSlot);
+          }
           printStatus("Waiting for interstitial to be ready...");
-
-          // Add event listener to register click handler once interstitial loads.
-          // If this event doesn't fire, check the browser console for errors.
-          googletag
-            .pubads()
-            .addEventListener("gameManualInterstitialSlotReady", function (slotReadyEvent) {
-              if (gamingInterstitialSlot === slotReadyEvent.slot) {
-                printStatus("Interstitial is ready.");
-
-                var button = document.getElementById("trigger");
-                button.style.display = "block";
-                button.addEventListener(
-                  "click",
-                  function () {
-                    slotReadyEvent.makeGameManualInterstitialVisible();
-                    printStatus("Interstitial is active.");
-                  },
-                  { once: true },
-                );
-              }
-            });
-
-          googletag.pubads().addEventListener("gameManualInterstitialSlotClosed", resumeGame);
+        } else {
+          printStatus("This device does not support interstitials.");
         }
       }
 
+      function addGamingInterstitialListeners() {
+        // Add event listener to register click handler once interstitial loads.
+        // If this event doesn't fire, check the browser console for errors.
+        googletag
+          .pubads()
+          .addEventListener("gameManualInterstitialSlotReady", function (slotReadyEvent) {
+            if (gamingInterstitialSlot === slotReadyEvent.slot) {
+              printStatus("Interstitial is ready.");
+
+              var button = document.getElementById("trigger");
+              button.style.display = "block";
+              button.addEventListener(
+                "click",
+                function () {
+                  pauseGame();
+
+                  slotReadyEvent.makeGameManualInterstitialVisible();
+                  printStatus("Interstitial is active.");
+                },
+                { once: true },
+              );
+            }
+          });
+
+        googletag.pubads().addEventListener("gameManualInterstitialSlotClosed", function () {
+          // Gaming interstitial ad slots are one-time use, so destroy the old slot
+          // and create a new one.
+          if (gamingInterstitialSlot) {
+            googletag.destroySlots([gamingInterstitialSlot]);
+          }
+          defineGamingInterstitialSlot(false);
+
+          resumeGame();
+        });
+      }
+
+      function pauseGame() {
+        // Code to pause the game.
+      }
+
       function resumeGame() {
-        if (!gamingInterstitialSlot) return;
-
-        document.getElementById("trigger").style.display = "none";
-
-        // Gaming interstitial ad slots are one-time use, so destroy the old slot
-        // and create a new one.
-        googletag.destroySlots([gamingInterstitialSlot]);
-        defineGamingInterstitialSlot();
-        googletag.display(gamingInterstitialSlot);
+        // Code to resume the game.
       }
 
       function printStatus(status) {

--- a/dist/display-gaming-interstitial-ad/ts/sample.ts
+++ b/dist/display-gaming-interstitial-ad/ts/sample.ts
@@ -13,7 +13,7 @@ let gamingInterstitialSlot: googletag.Slot | null;
 
 googletag.cmd.push(() => {
   // Define a gaming interstitial ad slot.
-  defineGamingInterstitialSlot(true);
+  defineGamingInterstitialSlot();
 
   // Add gaming interstitial event listeners.
   addGamingInterstitialListeners();
@@ -30,10 +30,12 @@ googletag.cmd.push(() => {
   // Ensure the first call to display comes after static ad slot
   // divs are defined. If you do not have any static ad slots, this
   // call can be made immediately after services are enabled.
-  googletag.display(gamingInterstitialSlot!);
+  if (gamingInterstitialSlot) {
+    googletag.display(gamingInterstitialSlot);
+  }
 });
 
-function defineGamingInterstitialSlot(delay: boolean) {
+function defineGamingInterstitialSlot(): boolean {
   document.getElementById("trigger")!.style.display = "none";
 
   gamingInterstitialSlot = googletag.defineOutOfPageSlot(
@@ -44,12 +46,11 @@ function defineGamingInterstitialSlot(delay: boolean) {
   // Slot returns null if the page or device does not support interstitials.
   if (gamingInterstitialSlot) {
     gamingInterstitialSlot.addService(googletag.pubads());
-    if (!delay) {
-      googletag.display(gamingInterstitialSlot);
-    }
     printStatus("Waiting for interstitial to be ready...");
+    return true;
   } else {
     printStatus("This device does not support interstitials.");
+    return false;
   }
 }
 
@@ -86,7 +87,10 @@ function addGamingInterstitialListeners() {
     if (gamingInterstitialSlot) {
       googletag.destroySlots([gamingInterstitialSlot]);
     }
-    defineGamingInterstitialSlot(false);
+
+    if (defineGamingInterstitialSlot()) {
+      googletag.display(gamingInterstitialSlot!);
+    }
 
     resumeGame();
   });

--- a/dist/display-gaming-interstitial-ad/ts/sample.ts
+++ b/dist/display-gaming-interstitial-ad/ts/sample.ts
@@ -13,7 +13,10 @@ let gamingInterstitialSlot: googletag.Slot | null;
 
 googletag.cmd.push(() => {
   // Define a gaming interstitial ad slot.
-  defineGamingInterstitialSlot();
+  defineGamingInterstitialSlot(true);
+
+  // Add gaming interstitial event listeners.
+  addGamingInterstitialListeners();
 
   // Define static ad slots.
   googletag
@@ -30,7 +33,9 @@ googletag.cmd.push(() => {
   googletag.display(gamingInterstitialSlot!);
 });
 
-function defineGamingInterstitialSlot() {
+function defineGamingInterstitialSlot(delay: boolean) {
+  document.getElementById("trigger")!.style.display = "none";
+
   gamingInterstitialSlot = googletag.defineOutOfPageSlot(
     "/6355419/Travel/Europe/France/Paris",
     googletag.enums.OutOfPageFormat.GAME_MANUAL_INTERSTITIAL,
@@ -39,46 +44,60 @@ function defineGamingInterstitialSlot() {
   // Slot returns null if the page or device does not support interstitials.
   if (gamingInterstitialSlot) {
     gamingInterstitialSlot.addService(googletag.pubads());
+    if (!delay) {
+      googletag.display(gamingInterstitialSlot);
+    }
     printStatus("Waiting for interstitial to be ready...");
-
-    // Add event listener to register click handler once interstitial loads.
-    // If this event doesn't fire, check the browser console for errors.
-    googletag
-      .pubads()
-      .addEventListener(
-        "gameManualInterstitialSlotReady",
-        (slotReadyEvent: googletag.events.GameManualInterstitialSlotReadyEvent) => {
-          if (gamingInterstitialSlot === slotReadyEvent.slot) {
-            printStatus("Interstitial is ready.");
-
-            const button = document.getElementById("trigger")!;
-            button.style.display = "block";
-            button.addEventListener(
-              "click",
-              () => {
-                slotReadyEvent.makeGameManualInterstitialVisible();
-                printStatus("Interstitial is active.");
-              },
-              { once: true },
-            );
-          }
-        },
-      );
-
-    googletag.pubads().addEventListener("gameManualInterstitialSlotClosed", resumeGame);
+  } else {
+    printStatus("This device does not support interstitials.");
   }
 }
 
+function addGamingInterstitialListeners() {
+  // Add event listener to register click handler once interstitial loads.
+  // If this event doesn't fire, check the browser console for errors.
+  googletag
+    .pubads()
+    .addEventListener(
+      "gameManualInterstitialSlotReady",
+      (slotReadyEvent: googletag.events.GameManualInterstitialSlotReadyEvent) => {
+        if (gamingInterstitialSlot === slotReadyEvent.slot) {
+          printStatus("Interstitial is ready.");
+
+          const button = document.getElementById("trigger")!;
+          button.style.display = "block";
+          button.addEventListener(
+            "click",
+            () => {
+              pauseGame();
+
+              slotReadyEvent.makeGameManualInterstitialVisible();
+              printStatus("Interstitial is active.");
+            },
+            { once: true },
+          );
+        }
+      },
+    );
+
+  googletag.pubads().addEventListener("gameManualInterstitialSlotClosed", () => {
+    // Gaming interstitial ad slots are one-time use, so destroy the old slot
+    // and create a new one.
+    if (gamingInterstitialSlot) {
+      googletag.destroySlots([gamingInterstitialSlot]);
+    }
+    defineGamingInterstitialSlot(false);
+
+    resumeGame();
+  });
+}
+
+function pauseGame() {
+  // Code to pause the game.
+}
+
 function resumeGame() {
-  if (!gamingInterstitialSlot) return;
-
-  document.getElementById("trigger")!.style.display = "none";
-
-  // Gaming interstitial ad slots are one-time use, so destroy the old slot
-  // and create a new one.
-  googletag.destroySlots([gamingInterstitialSlot]);
-  defineGamingInterstitialSlot();
-  googletag.display(gamingInterstitialSlot);
+  // Code to resume the game.
 }
 
 function printStatus(status: string) {

--- a/samples/display-gaming-interstitial-ad/sample.ts
+++ b/samples/display-gaming-interstitial-ad/sample.ts
@@ -13,7 +13,7 @@ let gamingInterstitialSlot: googletag.Slot|null;
 
 googletag.cmd.push(() => {
   // Define a gaming interstitial ad slot.
-  defineGamingInterstitialSlot(true);
+  defineGamingInterstitialSlot();
 
   // Add gaming interstitial event listeners.
   addGamingInterstitialListeners();
@@ -31,11 +31,13 @@ googletag.cmd.push(() => {
   // Ensure the first call to display comes after static ad slot
   // divs are defined. If you do not have any static ad slots, this
   // call can be made immediately after services are enabled.
-  googletag.display(gamingInterstitialSlot!);
+  if (gamingInterstitialSlot) {
+    googletag.display(gamingInterstitialSlot);
+  }
   // [END request_ads]
 });
 
-function defineGamingInterstitialSlot(delay: boolean) {
+function defineGamingInterstitialSlot(): boolean {
   document.getElementById('trigger')!.style.display = 'none';
 
   gamingInterstitialSlot = googletag.defineOutOfPageSlot(
@@ -46,13 +48,11 @@ function defineGamingInterstitialSlot(delay: boolean) {
   // Slot returns null if the page or device does not support interstitials.
   if (gamingInterstitialSlot) {
     gamingInterstitialSlot.addService(googletag.pubads());
-    if (!delay) {
-      googletag.display(gamingInterstitialSlot);
-    }
     printStatus('Waiting for interstitial to be ready...');
-  }
-  else {
+    return true;
+  } else {
     printStatus('This device does not support interstitials.');
+    return false;
   }
 }
 
@@ -88,7 +88,10 @@ function addGamingInterstitialListeners() {
         if (gamingInterstitialSlot) {
           googletag.destroySlots([gamingInterstitialSlot]);
         }
-        defineGamingInterstitialSlot(false);
+
+        if (defineGamingInterstitialSlot()) {
+          googletag.display(gamingInterstitialSlot!);
+        }
 
         resumeGame();
       });

--- a/samples/display-gaming-interstitial-ad/sample.ts
+++ b/samples/display-gaming-interstitial-ad/sample.ts
@@ -13,7 +13,10 @@ let gamingInterstitialSlot: googletag.Slot|null;
 
 googletag.cmd.push(() => {
   // Define a gaming interstitial ad slot.
-  defineGamingInterstitialSlot();
+  defineGamingInterstitialSlot(true);
+
+  // Add gaming interstitial event listeners.
+  addGamingInterstitialListeners();
 
   // Define static ad slots.
   googletag.defineSlot(
@@ -32,7 +35,9 @@ googletag.cmd.push(() => {
   // [END request_ads]
 });
 
-function defineGamingInterstitialSlot() {
+function defineGamingInterstitialSlot(delay: boolean) {
+  document.getElementById('trigger')!.style.display = 'none';
+
   gamingInterstitialSlot = googletag.defineOutOfPageSlot(
       '/6355419/Travel/Europe/France/Paris',
       googletag.enums.OutOfPageFormat.GAME_MANUAL_INTERSTITIAL,
@@ -41,45 +46,60 @@ function defineGamingInterstitialSlot() {
   // Slot returns null if the page or device does not support interstitials.
   if (gamingInterstitialSlot) {
     gamingInterstitialSlot.addService(googletag.pubads());
+    if (!delay) {
+      googletag.display(gamingInterstitialSlot);
+    }
     printStatus('Waiting for interstitial to be ready...');
-
-    // Add event listener to register click handler once interstitial loads.
-    // If this event doesn't fire, check the browser console for errors.
-    googletag.pubads().addEventListener(
-        'gameManualInterstitialSlotReady',
-        (slotReadyEvent:
-             googletag.events.GameManualInterstitialSlotReadyEvent) => {
-          if (gamingInterstitialSlot === slotReadyEvent.slot) {
-            printStatus('Interstitial is ready.');
-
-            const button = document.getElementById('trigger')!;
-            button.style.display = 'block';
-            button.addEventListener(
-                'click',
-                () => {
-                  slotReadyEvent.makeGameManualInterstitialVisible();
-                  printStatus('Interstitial is active.');
-                },
-                {once: true},
-            );
-          }
-        });
-
-    googletag.pubads().addEventListener(
-        'gameManualInterstitialSlotClosed', resumeGame);
+  }
+  else {
+    printStatus('This device does not support interstitials.');
   }
 }
 
+function addGamingInterstitialListeners() {
+  // Add event listener to register click handler once interstitial loads.
+  // If this event doesn't fire, check the browser console for errors.
+  googletag.pubads().addEventListener(
+      'gameManualInterstitialSlotReady',
+      (slotReadyEvent:
+            googletag.events.GameManualInterstitialSlotReadyEvent) => {
+        if (gamingInterstitialSlot === slotReadyEvent.slot) {
+          printStatus('Interstitial is ready.');
+
+          const button = document.getElementById('trigger')!;
+          button.style.display = 'block';
+          button.addEventListener(
+              'click',
+              () => {
+                pauseGame();
+
+                slotReadyEvent.makeGameManualInterstitialVisible();
+                printStatus('Interstitial is active.');
+              },
+              {once: true},
+          );
+        }
+      });
+
+  googletag.pubads().addEventListener(
+      'gameManualInterstitialSlotClosed', () => {
+        // Gaming interstitial ad slots are one-time use, so destroy the old slot
+        // and create a new one.
+        if (gamingInterstitialSlot) {
+          googletag.destroySlots([gamingInterstitialSlot]);
+        }
+        defineGamingInterstitialSlot(false);
+
+        resumeGame();
+      });
+}
+
+function pauseGame() {
+  // Code to pause the game.
+}
+
 function resumeGame() {
-  if (!gamingInterstitialSlot) return;
-
-  document.getElementById('trigger')!.style.display = 'none';
-
-  // Gaming interstitial ad slots are one-time use, so destroy the old slot
-  // and create a new one.
-  googletag.destroySlots([gamingInterstitialSlot]);
-  defineGamingInterstitialSlot();
-  googletag.display(gamingInterstitialSlot);
+  // Code to resume the game.
 }
 
 function printStatus(status: string) {


### PR DESCRIPTION
- Fix a bug where interstitial event listeners are registered every time `defineGamingInterstitialSlot` is called.
- Make placeholder `pauseGame` and `resumeGame` functions to make it clear where to implement those logics.